### PR TITLE
adds basic nifti data reading capability

### DIFF
--- a/medimg/nimsnifti.py
+++ b/medimg/nimsnifti.py
@@ -69,32 +69,25 @@ class NIMSNifti(medimg.MedImgReader, medimg.MedImgWriter):
 
     def __init__(self, path, load_data=False):
         super(NIMSNifti, self).__init__(path, load_data)
+        log.debug('reading %s' % path)
         try:
-            # TODO: load header only, unless load_data = True
+            # TODO: load sorting/identification header
             self.nifti = nibabel.load(path)
         except Exception as e:
             raise NIMSNiftiError(e)
-        # parse some header info from the nifti
-        # self.metadata._hdr = get header
-        # first simple parse of _hdr
 
-    def load_data(self, preloaded):
-        super(NIMSNifti, self).load_data(preloaded)
-        if not preloaded:
-            try:
-                nifti = nibabel.load(self.filepath)
-            except Exception as e:
-                raise NIMSNiftiError(e)
+        # TODO: read metadata from nifti extension header
 
-        # TODO: nibabel nifti header reader
-        # self.metadata.group
-        # self.metadata.project
-        # self.metadata.exam_uid
-        self.data = nifti.imagedata.squeeze()
-        self.qto_xyz = nifti.get_affine()
-        self.sform = nifti.get_sform()
-        self.qform = nifti.get_qform()
-        self.image_type = ['derived', 'nifti', self.filetype]
+        if load_data:
+            self.load_data()
+
+    def load_data(self):
+        super(NIMSNifti, self).load_data()
+        log.debug('loading data...')
+        self.data = {'': self.nifti.get_data()}
+        self.qto_xyz = self.nifti.get_affine()
+        self.sform = self.nifti.get_sform()
+        self.qform = self.nifti.get_qform()
         self.scan_type = 'unknown'   # FIXME
 
     @property


### PR DESCRIPTION
This re-enables nifti to montage conversion by adding very basic nifti reading capabilities. The simple nifti reader gets the minimum information necessary to convert to a montage.

This can be used from the bash command line.

```
nimsdata/nimsdata.py -i -v -p nifti -w montage nifti.nii.gz montage_file       
```

The above command will generate `montage_file.pyrdb`

By default, the montage writer will create a `pyrdb` montage file, without re-ordering the voxels.  
- To change the voxel order, specify a `voxel_order` as a writer_kwarg.  Valid value is a three character orientation string, such as `LPS`, `RAI`, etc. 
- To change the type of montage generated, specify `mtype` as a writer_kwarg.  Valid values are `sqlite` for pyrdb, `dir` for panojs directory, and `png` for flat image.

**Examples**

convert nifti.nii.gz to montage.pyrdb, with reordering voxels to LPS orientation:

```
nimsdata/nimsdata.py -i -v -p nifti -w montage --writer_kwarg "voxel_order=LPS" nifti.nii.gz montage_file
```

convert nifti.nii.gz to montage_file.png, no voxel reordering.

```
nimsdata/nimsdata.py -i -v -p nifti -w montage --writer_kwarg "mtype=png" nifti.nii.gz montage_file       
```
